### PR TITLE
Support working under VFIO passthrough

### DIFF
--- a/sys/dev/dpaa2/dpaa2_mc.c
+++ b/sys/dev/dpaa2/dpaa2_mc.c
@@ -649,6 +649,10 @@ dpaa2_ttos(enum dpaa2_dev_type type)
 		return ("dpcon");
 	case DPAA2_DEV_MAC:
 		return ("dpmac");
+	case DPAA2_DEV_MUX:
+		return ("dpdmux");
+	case DPAA2_DEV_SW:
+		return ("dpsw");
 	default:
 		break;
 	}
@@ -675,6 +679,10 @@ dpaa2_stot(const char *str)
 		return (DPAA2_DEV_CON);
 	} else if (COMPARE_TYPE(str, "dpmac")) {
 		return (DPAA2_DEV_MAC);
+	} else if (COMPARE_TYPE(str, "dpdmux")) {
+		return (DPAA2_DEV_MUX);
+	} else if (COMPARE_TYPE(str, "dpsw")) {
+		return (DPAA2_DEV_SW);
 	}
 
 	return (DPAA2_DEV_NOTYPE);

--- a/sys/dev/dpaa2/dpaa2_mc.h
+++ b/sys/dev/dpaa2/dpaa2_mc.h
@@ -156,7 +156,7 @@ struct dpaa2_devinfo {
 
 	uint32_t		 id;
 	uint32_t		 portal_id;
-	uint16_t		 icid;
+	uint32_t		 icid;
 
 	enum dpaa2_dev_type	 dtype;
 	struct resource_list	 resources;

--- a/sys/dev/dpaa2/dpaa2_mcp.h
+++ b/sys/dev/dpaa2/dpaa2_mcp.h
@@ -355,7 +355,7 @@ struct dpaa2_rc_attr {
 	uint32_t	cont_id;
 	uint32_t	portal_id;
 	uint32_t	options;
-	uint16_t	icid;
+	uint32_t	icid;
 };
 
 /**

--- a/sys/dev/dpaa2/dpaa2_ni.c
+++ b/sys/dev/dpaa2/dpaa2_ni.c
@@ -803,18 +803,17 @@ dpaa2_ni_setup(device_t dev)
 		device_printf(dev, "connected to %s (id=%d)\n",
 		    dpaa2_ttos(ep2_desc.type), ep2_desc.obj_id);
 
+		error = dpaa2_ni_set_mac_addr(dev, cmd, rc_token, ni_token);
+		if (error)
+			device_printf(dev, "%s: failed to set MAC "
+				      "address: error=%d\n", __func__, error);
+
 		if (ep2_desc.type == DPAA2_DEV_MAC) {
 			/*
 			 * This is the simplest case when DPNI is connected to
 			 * DPMAC directly.
 			 */
 			sc->mac.dpmac_id = ep2_desc.obj_id;
-
-			error = dpaa2_ni_set_mac_addr(dev, cmd, rc_token,
-			    ni_token);
-			if (error)
-				device_printf(dev, "%s: failed to set MAC "
-				    "address: error=%d\n", __func__, error);
 
 			link_type = DPAA2_MAC_LINK_TYPE_NONE;
 

--- a/sys/dev/dpaa2/dpaa2_ni.c
+++ b/sys/dev/dpaa2/dpaa2_ni.c
@@ -877,10 +877,10 @@ dpaa2_ni_setup(device_t dev)
 				device_printf(dev, "%s: DPMAC link type is not "
 				    "supported\n", __func__);
 			}
-		} else if (ep2_desc.type == DPAA2_DEV_NI) {
+		} else if (ep2_desc.type == DPAA2_DEV_NI ||
+			   ep2_desc.type == DPAA2_DEV_MUX ||
+			   ep2_desc.type == DPAA2_DEV_SW) {
 			dpaa2_ni_setup_fixed_link(sc);
-		} else {
-			/* TODO: Also DPSW, DPDMUX */
 		}
 	}
 

--- a/sys/dev/dpaa2/dpaa2_ni.c
+++ b/sys/dev/dpaa2/dpaa2_ni.c
@@ -826,10 +826,16 @@ dpaa2_ni_setup(device_t dev)
 			error = DPAA2_CMD_MAC_OPEN(sc->dev, child,
 			    dpaa2_mcp_tk(sc->cmd, sc->rc_token),
 			    sc->mac.dpmac_id, &mac_token);
+			/* Under VFIO, the DPMAC might be sitting in another
+			 * container (DPRC) we don't have access to.
+			 * Assume DPAA2_MAC_LINK_TYPE_FIXED if this is
+			 * the case.
+			 */
 			if (error) {
 				device_printf(dev, "%s: failed to open "
-				    "connected DPMAC: %d\n", __func__,
+				    "connected DPMAC: %d (assuming in other DPRC)\n", __func__,
 				    sc->mac.dpmac_id);
+					link_type = DPAA2_MAC_LINK_TYPE_FIXED;
 			} else {
 				error = DPAA2_CMD_MAC_GET_ATTRIBUTES(dev, child,
 				    sc->cmd, &attr);

--- a/sys/dev/dpaa2/dpaa2_rc.c
+++ b/sys/dev/dpaa2/dpaa2_rc.c
@@ -858,8 +858,7 @@ dpaa2_rc_get_attributes(device_t dev, device_t child, struct dpaa2_cmd *cmd,
 {
 	struct __packed dpaa2_rc_attr {
 		uint32_t	cont_id;
-		uint16_t	icid;
-		uint16_t	_reserved1;
+		uint32_t	icid;
 		uint32_t	options;
 		uint32_t	portal_id;
 	} *pattr;

--- a/sys/dev/dpaa2/dpaa2_types.h
+++ b/sys/dev/dpaa2/dpaa2_types.h
@@ -37,6 +37,8 @@ enum dpaa2_dev_type {
 	DPAA2_DEV_BP,		/* Buffer Pool */
 	DPAA2_DEV_CON,		/* Concentrator */
 	DPAA2_DEV_MAC,		/* MAC object */
+	DPAA2_DEV_MUX,		/* MUX (Datacenter bridge) object */
+	DPAA2_DEV_SW,		/* Ethernet Switch */
 
 	DPAA2_DEV_NOTYPE	/* Shouldn't be assigned to any DPAA2 device. */
 };


### PR DESCRIPTION
This fixes some issues that were preventing the driver from working under VFIO / QEMU passthrough.
This has been tested with muvirt on Ten64 and MC firmware 10.20 (see our forum on how to set this up: https://forum.traverse.com.au/t/restool-in-muvirt/63/17?u=mcbridematt).

There are some changes to VFIO in more recent MC firmwares (>10.24) and QEMU versions so some adjustments may still be required.

Key changes:
1. Extend ICID to 32-bits. The top 16 bits (marked as 'reserved' in NXP documentation) are used to differentiate host and guest interrupts in the (v)GIC [interrupt controller]. Without the full ICID the interrupts will not be routed in the kernel
```
dpaa2_rc0: Isolation context ID: 23 # Bare metal
dpaa2_rc0: Isolation context ID: 65536 # VM
```
3. Treat an unreachable DPMAC (when we ask if it is PHY or FIXED) as a FIXED link. 
(This is because the DPMAC is usually sitting in the host / root DPRC and cannot be accessed by the child DPRC)
Ideally, this would be avoided by having the DPMAC driver 'own' the PHY connection (signalling the MC on MII/MDIO events), and the DPNI receiving it's link state indications from the MC via interrupts. However, it's not worth the effort to implement this unless FreeBSD gains the ability to act as a host for VFIO passthrough.
4. Support non-DPMAC partner types: DPNI, DPDMUX, DPSW.
These function exactly the same as a DPMAC in FIXED mode, but their MAC addresses are set in the DPNI object only, so move the MAC query out of the DPMAC only section.