### PR TITLE
DPAA2: properly set link state on startup

### DIFF
--- a/sys/conf/files.arm64
+++ b/sys/conf/files.arm64
@@ -337,6 +337,7 @@ dev/dpaa2/dpaa2_mac.c				optional SOC_NXP_LS dpaa2
 dev/dpaa2/dpaa2_con.c				optional SOC_NXP_LS dpaa2
 dev/dpaa2/dpaa2_mc_acpi.c			optional SOC_NXP_LS dpaa2 acpi
 dev/dpaa2/dpaa2_mc_fdt.c			optional SOC_NXP_LS dpaa2 fdt
+dev/dpaa2/memac_mdio_if.m			optional SOC_NXP_LS dpaa2 acpi | SOC_NXP_LS dpaa2 fdt
 dev/dpaa2/memac_mdio_acpi.c			optional SOC_NXP_LS dpaa2 acpi
 
 ##

--- a/sys/dev/dpaa2/memac_mdio_if.m
+++ b/sys/dev/dpaa2/memac_mdio_if.m
@@ -1,0 +1,37 @@
+#-
+# SPDX-License-Identifier: BSD-2-Clause
+#
+# Copyright (c) 2022, Bjoern A. Zeeb
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+# OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+# OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+# SUCH DAMAGE.
+#
+# $FreeBSD$
+#
+
+#include <machine/bus.h>
+
+INTERFACE memac_mdio;
+
+METHOD int set_ni_dev {
+	device_t		 dev;
+	device_t		 nidev;
+};

--- a/sys/modules/dpaa2/Makefile
+++ b/sys/modules/dpaa2/Makefile
@@ -38,6 +38,7 @@ SRCS+=	dpaa2_mc_fdt.c \
 
 MFILES=	dev/dpaa2/dpaa2_cmd_if.m \
 	dev/dpaa2/dpaa2_swp_if.m \
-	dev/dpaa2/dpaa2_mc_if.m
+	dev/dpaa2/dpaa2_mc_if.m \
+	dev/dpaa2/memac_mdio_if.m
 
 .include <bsd.kmod.mk>


### PR DESCRIPTION
Factor out the link-state change tracking from media_change into
a new function dpaa2_ni_miibus_statchg().  There use mii information
for the link state as ifp->if_linkstate only gets updated after other
mii functions are called and thus lacks behind.

Add a new bus function to memac_mdio so we can set the dpni interface
and call MIIBUS_STATCHG on the dpni and pass that through to
dpaa2_ni_miibus_statchg().

It is a bit of a weird setup with two parallel device tress off ACPI
as ideally memac_mdio0 would be a child of dpaa2_ni0.
We will see how this will work with FDT at some point but at least the
current way of doing is flexible enough.
Currently we need to make sure MC0 can discover the memac_mdio via the
ACPI reference upon attach and have a way for DPNI to query that.
The new bus function now allows us to set a back-pointer in the other
direction from dpaa2_ni_setup().

```
nexus0
  acpi0
    dpaa2_mc0
      dpaa2_rc0
        dpaa2_ni0
    memac_mdio0
      memacphy0
        miibus1
          atphy0
    memac_mdio1
```

Most importantly and not to be missed  at the end of dpaa2_ni_init()
make sure we initialize the link state as otherwise we will not see
any interrupts.  That can be observed by a hanging NFS Root mount
for example, whereas with the previous code ifconfig would trigger
a SIOCGIFMEDIA call (from multi-user at some point) which then
indirectly and more by accident set the the MAC LINK STATE via
DPAA2_CMD_MAC_SET_LINK_STATE() and got the interface started.

This fixes #7 